### PR TITLE
🔧Add prd_cidr range to open API

### DIFF
--- a/app.deploy
+++ b/app.deploy
@@ -2,7 +2,7 @@
 deploy {
     architecture_type = "aws-ecs-service-type-1"
     jenkinsfile_name  = "app.deploy" 
-
+    prd_cidr          = "0.0.0.0/0"
     projectName = "api-portal-reports"
     environments = "qa,prd"
     docker_image_type = "alpine"


### PR DESCRIPTION
Since include portal is now public, adding prd_cidr variable will open up include-users-api to include portal, allowing it to resolve outside of prefix list used for development.