### PR TITLE
🔒️ Add container scan

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,0 +1,21 @@
+name: build
+on:
+  pull_request:
+    
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t ${{ github.sha }} .
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ github.sha }}'
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
For NIST 800-171 security remediation, we're required to assess potential security vulnerabilities before they go to production. This PR will add a Github action to build and scan the container for Critical and High vulnerabilities.

Tracked in DCF-18 Review applications for security vulnerabilities prior to deployment to production
